### PR TITLE
Make a few changes to support Unity 2019

### DIFF
--- a/Packages/jp.keijiro.metatex/Editor/MetatexImporter.cs
+++ b/Packages/jp.keijiro.metatex/Editor/MetatexImporter.cs
@@ -1,6 +1,10 @@
 using UnityEngine;
 using UnityEditor;
+#if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
+#else
+using UnityEditor.Experimental.AssetImporters;
+#endif
 using Klak.Chromatics;
 
 namespace Metatex {

--- a/Packages/jp.keijiro.metatex/Editor/MetatexImporterEditor.cs
+++ b/Packages/jp.keijiro.metatex/Editor/MetatexImporterEditor.cs
@@ -1,6 +1,10 @@
 using UnityEngine;
 using UnityEditor;
+#if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
+#else
+using UnityEditor.Experimental.AssetImporters;
+#endif
 
 namespace Metatex {
 

--- a/Packages/jp.keijiro.metatex/Editor/Utils.cs
+++ b/Packages/jp.keijiro.metatex/Editor/Utils.cs
@@ -58,26 +58,28 @@ static class EmojiDownloader
         var filename = $"emoji_u{NormalizeCode(code)}.png";
         var tempFilePath = "Temp/" + filename;
 
-        using var client = new System.Net.WebClient();
-        client.DownloadFile($"{BaseURL}/{filename}", tempFilePath);
-        var bytes = System.IO.File.ReadAllBytes(tempFilePath);
+        using (var client = new System.Net.WebClient())
+        {
+            client.DownloadFile($"{BaseURL}/{filename}", tempFilePath);
+            var bytes = System.IO.File.ReadAllBytes(tempFilePath);
 
-        var temp = new Texture2D(1, 1);
-        ImageConversion.LoadImage(temp, bytes);
+            var temp = new Texture2D(1, 1);
+            ImageConversion.LoadImage(temp, bytes);
 
-        var rt = new RenderTexture(texture.width, texture.height, 0);
+            var rt = new RenderTexture(texture.width, texture.height, 0);
 
-        var prevRT = RenderTexture.active;
-        Graphics.Blit(temp, rt);
+            var prevRT = RenderTexture.active;
+            Graphics.Blit(temp, rt);
 
-        texture.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
-        if (compression) texture.Compress(true);
-        texture.Apply(true, true);
+            texture.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+            if (compression) texture.Compress(true);
+            texture.Apply(true, true);
 
-        RenderTexture.active = prevRT;
+            RenderTexture.active = prevRT;
 
-        Object.DestroyImmediate(rt);
-        Object.DestroyImmediate(temp);
+            Object.DestroyImmediate(rt);
+            Object.DestroyImmediate(temp);
+        }
     }
 }
 

--- a/Packages/jp.keijiro.metatex/Editor/Utils.cs
+++ b/Packages/jp.keijiro.metatex/Editor/Utils.cs
@@ -58,28 +58,26 @@ static class EmojiDownloader
         var filename = $"emoji_u{NormalizeCode(code)}.png";
         var tempFilePath = "Temp/" + filename;
 
-        using (var client = new System.Net.WebClient())
-        {
-            client.DownloadFile($"{BaseURL}/{filename}", tempFilePath);
-            var bytes = System.IO.File.ReadAllBytes(tempFilePath);
+        using var client = new System.Net.WebClient();
+        client.DownloadFile($"{BaseURL}/{filename}", tempFilePath);
+        var bytes = System.IO.File.ReadAllBytes(tempFilePath);
 
-            var temp = new Texture2D(1, 1);
-            ImageConversion.LoadImage(temp, bytes);
+        var temp = new Texture2D(1, 1);
+        ImageConversion.LoadImage(temp, bytes);
 
-            var rt = new RenderTexture(texture.width, texture.height, 0);
+        var rt = new RenderTexture(texture.width, texture.height, 0);
 
-            var prevRT = RenderTexture.active;
-            Graphics.Blit(temp, rt);
+        var prevRT = RenderTexture.active;
+        Graphics.Blit(temp, rt);
 
-            texture.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
-            if (compression) texture.Compress(true);
-            texture.Apply(true, true);
+        texture.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+        if (compression) texture.Compress(true);
+        texture.Apply(true, true);
 
-            RenderTexture.active = prevRT;
+        RenderTexture.active = prevRT;
 
-            Object.DestroyImmediate(rt);
-            Object.DestroyImmediate(temp);
-        }
+        Object.DestroyImmediate(rt);
+        Object.DestroyImmediate(temp);
     }
 }
 


### PR DESCRIPTION
In theory it also supports 2017.1 but I haven't tested!
Changes done:
Do the old way of "using" for the lower API Compatibility Level
Add if else define statement to support the Experimental namespace for AssetImporters